### PR TITLE
Review: idioms, eliminating panics for traps, and fix cargo dep

### DIFF
--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -54,15 +54,14 @@ impl WasiHttp {
         request_id: crate::default_outgoing_http::OutgoingRequest,
         options: Option<crate::default_outgoing_http::RequestOptions>,
     ) -> wasmtime::Result<crate::default_outgoing_http::FutureIncomingResponse> {
-        let opts = match options {
-            Some(o) => o,
+        let opts = options.unwrap_or(
             // TODO: Configurable defaults here?
-            None => RequestOptions {
+            RequestOptions {
                 connect_timeout_ms: Some(600 * 1000),
                 first_byte_timeout_ms: Some(600 * 1000),
                 between_bytes_timeout_ms: Some(600 * 1000),
             },
-        };
+        );
         let connect_timeout =
             Duration::from_millis(opts.connect_timeout_ms.unwrap_or(600 * 1000).into());
         let first_bytes_timeout =

--- a/crates/wasi-http/src/streams_impl.rs
+++ b/crates/wasi-http/src/streams_impl.rs
@@ -1,7 +1,7 @@
 use crate::poll::Pollable;
 use crate::streams::{InputStream, OutputStream, StreamError};
 use crate::WasiHttp;
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use std::vec::Vec;
 
 impl crate::streams::Host for WasiHttp {
@@ -10,19 +10,18 @@ impl crate::streams::Host for WasiHttp {
         stream: InputStream,
         len: u64,
     ) -> wasmtime::Result<Result<(Vec<u8>, bool), StreamError>> {
-        match self.streams.get_mut(&stream) {
-            Some(s) => {
-                if len == 0 {
-                    Ok(Ok((bytes::Bytes::new().to_vec(), s.len() > 0)))
-                } else if s.len() > len.try_into()? {
-                    let result = s.split_to(len.try_into()?);
-                    Ok(Ok((result.to_vec(), false)))
-                } else {
-                    s.truncate(s.len());
-                    Ok(Ok((s.clone().to_vec(), true)))
-                }
-            }
-            None => bail!("not found"),
+        let s = self
+            .streams
+            .get_mut(&stream)
+            .ok_or_else(|| anyhow!("stream not found: {stream}"))?;
+        if len == 0 {
+            Ok(Ok((bytes::Bytes::new().to_vec(), s.len() > 0)))
+        } else if s.len() > len.try_into()? {
+            let result = s.split_to(len.try_into()?);
+            Ok(Ok((result.to_vec(), false)))
+        } else {
+            s.truncate(s.len());
+            Ok(Ok((s.clone().to_vec(), true)))
         }
     }
 
@@ -31,18 +30,19 @@ impl crate::streams::Host for WasiHttp {
         _this: InputStream,
         _len: u64,
     ) -> wasmtime::Result<Result<(u64, bool), StreamError>> {
-        todo!();
+        bail!("unimplemented: skip");
     }
 
     fn subscribe_to_input_stream(&mut self, _this: InputStream) -> wasmtime::Result<Pollable> {
-        todo!();
+        bail!("unimplemented: subscribe_to_input_stream");
     }
 
     fn drop_input_stream(&mut self, stream: InputStream) -> wasmtime::Result<()> {
-        match self.streams.get_mut(&stream) {
-            Some(r) => r.truncate(0),
-            None => {}
-        }
+        let r = self
+            .streams
+            .get_mut(&stream)
+            .ok_or_else(|| anyhow!("no such input-stream {stream}"))?;
+        r.truncate(0);
         Ok(())
     }
 
@@ -53,7 +53,7 @@ impl crate::streams::Host for WasiHttp {
     ) -> wasmtime::Result<Result<u64, StreamError>> {
         // TODO: Make this a real write not a replace.
         self.streams.insert(this, bytes::Bytes::from(buf.clone()));
-        Ok(Ok(buf.len().try_into().unwrap()))
+        Ok(Ok(buf.len().try_into()?))
     }
 
     fn write_zeroes(
@@ -61,7 +61,7 @@ impl crate::streams::Host for WasiHttp {
         _this: OutputStream,
         _len: u64,
     ) -> wasmtime::Result<Result<u64, StreamError>> {
-        todo!();
+        bail!("unimplemented: write_zeroes");
     }
 
     fn splice(
@@ -70,7 +70,7 @@ impl crate::streams::Host for WasiHttp {
         _src: InputStream,
         _len: u64,
     ) -> wasmtime::Result<Result<(u64, bool), StreamError>> {
-        todo!();
+        bail!("unimplemented: splice");
     }
 
     fn forward(
@@ -78,14 +78,14 @@ impl crate::streams::Host for WasiHttp {
         _this: OutputStream,
         _src: InputStream,
     ) -> wasmtime::Result<Result<u64, StreamError>> {
-        todo!();
+        bail!("unimplemented: forward");
     }
 
     fn subscribe_to_output_stream(&mut self, _this: OutputStream) -> wasmtime::Result<Pollable> {
-        todo!();
+        bail!("unimplemented: subscribe_to_output_stream");
     }
 
     fn drop_output_stream(&mut self, _this: OutputStream) -> wasmtime::Result<()> {
-        todo!();
+        bail!("unimplemented: drop_output_stream");
     }
 }


### PR DESCRIPTION
This PR
* makes all of the linker functions return an anyhow::Result<_>, which means they can trap on an error, instead of panic.
* systematically removes panics throughout the crate, in favor of trapping. this includes swapping `todo!()` for `bail!("unimplemented: <func name>")`, and replacing all `.unwrap()` invocations with trapping
* fixes various idiomatic stuff, and exits on errors where it appeared to be missing - frequently this is replacing pattern matching an `Option` with `.ok_or_else(|| anyhow!("some error message"))?`