### PR TITLE
wasi-http: fix cargo.toml file and publish script to work together

### DIFF
--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-    name        = "wasi-http"
-    version     = "0.0.1"
-    authors.workspace = true
-    edition.workspace = true
-    repository  = "https://github.com/WebAssembly/wasi-http"
-    license     = "Apache-2.0 WITH LLVM-exception"
-    description = "Experimental HTTP library for WebAssembly in Wasmtime"
-    readme      = "readme.md"
+name = "wasi-http"
+version = "0.0.1"
+authors.workspace = true
+edition.workspace = true
+repository = "https://github.com/bytecodealliance/wasmtime"
+license = "Apache-2.0 WITH LLVM-exception"
+description = "Experimental HTTP library for WebAssembly in Wasmtime"
+readme = "readme.md"
 
 [dependencies]
-    anyhow = { workspace = true }
-    bytes = "1.1.0"
-    hyper = { version = "1.0.0-rc.3", features = ["full"] }
-    tokio = { version = "1", default-features = false, features = ["net", "rt-multi-thread", "time"] }
-    tokio-native-tls = { version = "0.3.1" }
-    futures = { version = "0.3.27" }
-    http-body = "1.0.0-rc.2"
-    http-body-util = "0.1.0-rc.2"
-    thiserror = { workspace = true }
-    wasmtime = { workspace = true, features = ['component-model'] }
+anyhow = { workspace = true }
+bytes = "1.1.0"
+hyper = { version = "1.0.0-rc.3", features = ["full"] }
+tokio = { version = "1", default-features = false, features = ["net", "rt-multi-thread", "time"] }
+tokio-native-tls = { version = "0.3.1" }
+futures = { version = "0.3.27" }
+http-body = "1.0.0-rc.2"
+http-body-util = "0.1.0-rc.2"
+thiserror = { workspace = true }
+wasmtime = { workspace = true, features = ['component-model'] }

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -64,6 +64,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wasi-common",
     "wasi-cap-std-sync",
     "wasi-tokio",
+    "wasi-http",
     // other misc wasmtime crates
     "wasmtime-wasi",
     "wasmtime-wasi-crypto",


### PR DESCRIPTION
unfortunately, the publish script doesn't use a proper toml parser (in order to not have any dependencies), so the whitespace has to be the trivial expected case.

then, add wasi-http to the list of crates to publish.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
